### PR TITLE
Add RViz2

### DIFF
--- a/install_guide.md
+++ b/install_guide.md
@@ -38,7 +38,7 @@ python3.11 -m pip install --global-option=build_ext \
        pygraphviz
 python3.11 -m pip install -U \
       argcomplete catkin_pkg colcon-common-extensions coverage \
-      cryptography empy flake8 flake8-blind-except==0.1.1 flake8-builtins \
+      cryptography empy==3.3.4 flake8 flake8-blind-except==0.1.1 flake8-builtins \
       flake8-class-newline flake8-comprehensions flake8-deprecated \
       flake8-docstrings flake8-import-order flake8-quotes \
       importlib-metadata lark==1.1.1 lxml matplotlib mock mypy==0.931 netifaces \

--- a/install_guide.md
+++ b/install_guide.md
@@ -54,6 +54,13 @@ vcs import src < ros2.repos
 ```
 
 ```bash
+patch -l < patches/ros2_console_bridge_vendor.patch
+patch -l < patches/ros2_rviz_ogre_vendor.patch
+```
+
+```bash
+export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$(brew --prefix qt@5)
+export PATH=$PATH:$(brew --prefix qt@5)/bin
 export COLCON_EXTENSION_BLOCKLIST=colcon_core.event_handler.desktop_notification
 python3.11 -m colcon build --symlink-install --cmake-args \
             -DBUILD_TESTING=OFF \

--- a/patches/ros2_console_bridge_vendor.patch
+++ b/patches/ros2_console_bridge_vendor.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9fa3780..5dd3001 100644
+--- a/CMakeLists.txt
++++ src/ros2/console_bridge_vendor/CMakeLists.txt
+@@ -5,6 +5,7 @@ project(console_bridge_vendor)
+ # Default to C++14
+ if(NOT CMAKE_CXX_STANDARD)
+   set(CMAKE_CXX_STANDARD 14)
++  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ endif()
+ 
+ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/patches/ros2_rviz_ogre_vendor.patch
+++ b/patches/ros2_rviz_ogre_vendor.patch
@@ -1,0 +1,147 @@
+diff --git a/rviz_ogre_vendor/C4267.patch b/rviz_ogre_vendor/C4267.patch
+new file mode 100644
+index 00000000..1d019579
+--- /dev/null
++++ src/ros2/rviz/rviz_ogre_vendor/C4267.patch
+@@ -0,0 +1,23 @@
++diff --git a/OgreMain/include/OgreRenderSystem.h b/OgreMain/include/OgreRenderSystem.h
++index cf82fdc0f..711228e3a 100644
++--- a/OgreMain/include/OgreRenderSystem.h
+++++ b/OgreMain/include/OgreRenderSystem.h
++@@ -971,12 +971,12 @@ namespace Ogre
++         <i>pixels</i>.
++         */
++         virtual void setScissorTest(bool enabled, const Rect& rect = Rect()) = 0;
++-        /// @deprecated
++-        OGRE_DEPRECATED void setScissorTest(bool enabled, size_t left, size_t top = 0,
++-                                            size_t right = 800, size_t bottom = 600)
++-        {
++-            setScissorTest(enabled, Rect(left, top, right, bottom));
++-        }
+++        // /// @deprecated
+++        // OGRE_DEPRECATED void setScissorTest(bool enabled, size_t left, size_t top = 0,
+++        //                                     size_t right = 800, size_t bottom = 600)
+++        // {
+++        //     setScissorTest(enabled, Rect(left, top, right, bottom));
+++        // }
++ 
++         /** Clears one or more frame buffers on the active render target. 
++         @param buffers Combination of one or more elements of FrameBufferType
+diff --git a/rviz_ogre_vendor/CMakeLists.txt b/rviz_ogre_vendor/CMakeLists.txt
+index 3f5fda2e..7d8699c1 100644
+--- a/rviz_ogre_vendor/CMakeLists.txt
++++ src/ros2/rviz/rviz_ogre_vendor/CMakeLists.txt
+@@ -125,7 +125,11 @@ macro(build_ogre)
+     set(OGRE_CXX_FLAGS "${OGRE_CXX_FLAGS} /w /EHsc")
+   elseif(APPLE)
+     set(OGRE_CXX_FLAGS "${OGRE_CXX_FLAGS} -std=c++14 -stdlib=libc++ -w")
+-    list(APPEND extra_cmake_args "-DCMAKE_OSX_ARCHITECTURES='x86_64'")
++    if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "arm64")
++      list(APPEND extra_cmake_args "-DCMAKE_OSX_ARCHITECTURES='arm64'")
++    else()
++      list(APPEND extra_cmake_args "-DCMAKE_OSX_ARCHITECTURES='x86_64'")
++    endif()
+   else()  # Linux
+     set(OGRE_C_FLAGS "${OGRE_C_FLAGS} -w")
+     # include Clang -Wno-everything to disable warnings in that build. GCC doesn't mind it
+@@ -161,9 +165,9 @@ macro(build_ogre)
+ 
+   find_package(Patch REQUIRED)
+   include(ExternalProject)
+-  ExternalProject_Add(ogre-v1.12.1
+-    URL https://github.com/OGRECave/ogre/archive/v1.12.1.zip
+-    URL_MD5 cdbea4006d223c173e0a93864111b936
++  ExternalProject_Add(ogre-v1.12.10
++    URL https://github.com/OGRECave/ogre/archive/v1.12.10.zip
++    URL_MD5 c1b870955efddf539385094e9034e7f7
+     TIMEOUT 1200
+     LOG_CONFIGURE ${should_log}
+     LOG_BUILD ${should_log}
+@@ -179,7 +183,8 @@ macro(build_ogre)
+       -DOGRE_CONFIG_THREADS:STRING=0
+       -DOGRE_RESOURCEMANAGER_STRICT:STRING=2
+       -DCMAKE_SKIP_INSTALL_RPATH:BOOL=ON
+-      -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/ogre_install
++      -DCMAKE_STAGING_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/ogre_install
++      -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor
+       -DOGRE_BUILD_LIBS_AS_FRAMEWORKS:BOOL=OFF
+       -DOGRE_BUILD_COMPONENT_PYTHON:BOOL=FALSE
+       -DOGRE_BUILD_COMPONENT_JAVA:BOOL=FALSE
+@@ -188,18 +193,19 @@ macro(build_ogre)
+       ${extra_cmake_args}
+       -Wno-dev
+     PATCH_COMMAND
+-      ${Patch_EXECUTABLE} -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/pragma-patch.diff &&
+-      ${Patch_EXECUTABLE} -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/fix-arm64.diff &&
+-      ${Patch_EXECUTABLE} -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/relocatable.patch
++      ${Patch_EXECUTABLE} -p1 -N -l < ${CMAKE_CURRENT_SOURCE_DIR}/pragma-patch.diff &&
++      ${Patch_EXECUTABLE} -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/relocatable.patch &&
++      ${CMAKE_COMMAND} -E rename CMake/FeatureSummary.cmake CMake/OgreFeatureSummary.cmake &&
++      ${Patch_EXECUTABLE} -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/C4267.patch
+     COMMAND
+-      ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/FindFreetype.cmake ${CMAKE_CURRENT_BINARY_DIR}/ogre-v1.12.1-prefix/src/ogre-v1.12.1/CMake/Packages/FindFreetype.cmake
++      ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/FindFreetype.cmake ${CMAKE_CURRENT_BINARY_DIR}/ogre-v1.12.10-prefix/src/ogre-v1.12.10/CMake/Packages/FindFreetype.cmake
+   )
+ 
+   if(BUILDING_FREETYPE_LOCALLY)
+-    add_dependencies(ogre-v1.12.1 freetype-2.8.1)
++    add_dependencies(ogre-v1.12.10 freetype-2.8.1)
+   endif()
+   if(BUILDING_ZLIB_LOCALLY)
+-    add_dependencies(ogre-v1.12.1 zlib-1.2.11)
++    add_dependencies(ogre-v1.12.10 zlib-1.2.11)
+   endif()
+ 
+   # The external project will install to the build folder, but we'll install that on make install.
+@@ -207,7 +213,7 @@ macro(build_ogre)
+     DIRECTORY
+       ${CMAKE_CURRENT_BINARY_DIR}/ogre_install/
+     DESTINATION
+-      ${CMAKE_INSTALL_PREFIX}/opt/rviz_ogre_vendor
++      opt/rviz_ogre_vendor
+     USE_SOURCE_PERMISSIONS
+   )
+ endmacro()
+diff --git a/rviz_ogre_vendor/pragma-patch.diff b/rviz_ogre_vendor/pragma-patch.diff
+index 911a4b7c..132ca02a 100644
+--- a/rviz_ogre_vendor/pragma-patch.diff
++++ src/ros2/rviz/rviz_ogre_vendor/pragma-patch.diff
+@@ -1814,14 +1814,14 @@ diff --git a/PlugIns/OctreeZone/CMakeLists.txt b/PlugIns/OctreeZone/CMakeLists.t
+ @@ -23,6 +23,11 @@ generate_export_header(Plugin_OctreeZone
+      EXPORT_MACRO_NAME _OgreOctreeZonePluginExport
+      EXPORT_FILE_NAME ${PROJECT_BINARY_DIR}/include/OgreOctreeZonePrerequisites.h)
+-
++ 
+ +if (UNIX)
+ +  set_property(TARGET Plugin_OctreeZone APPEND PROPERTY
+ +    INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/${OGRE_LIB_DIRECTORY}/OGRE)
+ +endif ()
+ +
+  ogre_config_framework(Plugin_OctreeZone)
+-
++ 
+  ogre_config_plugin(Plugin_OctreeZone)
+ diff --git a/OgreMain/include/OgreTimer.h b/OgreMain/include/OgreTimer.h
+ --- a/OgreMain/include/OgreTimer.h	2019-06-24 16:04:20.000000000 -0700
+@@ -1845,4 +1845,20 @@ diff --git a/OgreMain/include/OgreTimer.h b/OgreMain/include/OgreTimer.h
+ +#pragma warning(pop)
+ +#endif
+  #endif
+-
++diff --git a/CMake/Utils/PrecompiledHeader.cmake b/CMake/Utils/PrecompiledHeader.cmake
++index bfb0059..62b4f6d 100644
++--- a/CMake/Utils/PrecompiledHeader.cmake
+++++ b/CMake/Utils/PrecompiledHeader.cmake
++@@ -340,7 +340,11 @@ MACRO(ADD_NATIVE_PRECOMPILED_HEADER _targetName _input)
++     if(NOT OGRE_ENABLE_PRECOMPILED_HEADERS)
++         # do nothing
++     elseif(CMAKE_VERSION GREATER_EQUAL "3.16")
++-        target_precompile_headers(${_targetName} PRIVATE ${_input})
+++        if(APPLE)
+++            add_compile_options((-Xclang -include -Xclang ${_input}))
+++        else()
+++            target_precompile_headers(${_targetName} PRIVATE ${_input})
+++        endif()
++     elseif(CMAKE_GENERATOR MATCHES "^Visual.*$")
++ 
++         # Auto include the precompile (useful for moc processing, since the use of

--- a/ros2.repos
+++ b/ros2.repos
@@ -15,6 +15,10 @@ repositories:
     type: git
     url: https://github.com/ament/ament_lint.git
     version: humble
+  ament/googletest:
+    type: git
+    url: https://github.com/ament/googletest.git
+    version: humble
   ament/uncrustify_vendor:
     type: git
     url: https://github.com/ament/uncrustify_vendor.git
@@ -150,6 +154,10 @@ repositories:
   ros2/rpyutils:
     type: git
     url: https://github.com/ros2/rpyutils.git
+    version: humble
+  ros2/rviz:
+    type: git
+    url: https://github.com/ros2/rviz.git
     version: humble
   ros2/spdlog_vendor:
     type: git


### PR DESCRIPTION
I add to build RViz2. So, I back-ported the following package from iron branch.

- console_bridge_vendor
- rviz_ogre_vendor

I checked on the following environment.

- macOS Sonoma 14.0
- M1 MacBook Air

```shell
rviz2
```

<img width="837" alt="スクリーンショット 2023-12-20 22 49 13" src="https://github.com/TakanoTaiga/ros2_m1_native/assets/2630323/fd0dc21a-582b-4503-8a27-407eb5d17888">