### PR TITLE
Add rqt tools

### DIFF
--- a/install_guide.md
+++ b/install_guide.md
@@ -17,7 +17,7 @@
 brew install \
     asio assimp bison bullet cmake console_bridge cppcheck \
     cunit eigen freetype graphviz opencv openssl orocos-kdl pcre poco \
-    pyqt5 python qt@5 sip spdlog tinyxml tinyxml2 wget
+    py3cairo pyqt5 python qt@5 sip spdlog tinyxml tinyxml2 wget
 ```
 
 ```bash
@@ -50,13 +50,14 @@ vcs import src < ros2.repos
 ```bash
 patch -l < patches/ros2_console_bridge_vendor.patch
 patch -l < patches/ros2_rviz_ogre_vendor.patch
+patch -l < patches/ros_visualization_rqt_bag.patch
 ```
 
 ```bash
 export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$(brew --prefix qt@5)
 export PATH=$PATH:$(brew --prefix qt@5)/bin
 export COLCON_EXTENSION_BLOCKLIST=colcon_core.event_handler.desktop_notification
-python3.11 -m colcon build --symlink-install --cmake-args \
+python3.11 -m colcon build --symlink-install --packages-skip-by-dep qt_gui_cpp --packages-skip qt_gui_cpp --cmake-args \
             -DBUILD_TESTING=OFF \
             -DTHIRDPARTY=FORCE \
             -DCMAKE_BUILD_TYPE=Release \

--- a/patches/ros_visualization_rqt_bag.patch
+++ b/patches/ros_visualization_rqt_bag.patch
@@ -1,0 +1,35 @@
+diff --git a/rqt_bag_plugins/src/rqt_bag_plugins/image_timeline_renderer.py b/rqt_bag_plugins/src/rqt_bag_plugins/image_timeline_renderer.py
+index d368bc9..666c1bd 100755
+--- a/rqt_bag_plugins/src/rqt_bag_plugins/image_timeline_renderer.py
++++ src/ros-visualization/rqt_bag/rqt_bag_plugins/src/rqt_bag_plugins/image_timeline_renderer.py
+@@ -40,8 +40,7 @@ if (
+     'PyQt5' in sys.modules
+ ):
+     sys.modules['PyQt5'] = None
+-from PIL import Image
+-from PIL.ImageQt import ImageQt
++from PIL import Image, ImageQt
+ 
+ from rqt_bag import TimelineCache, TimelineRenderer
+ 
+diff --git a/rqt_bag_plugins/src/rqt_bag_plugins/image_view.py b/rqt_bag_plugins/src/rqt_bag_plugins/image_view.py
+index bb67c73..e6126de 100755
+--- a/rqt_bag_plugins/src/rqt_bag_plugins/image_view.py
++++ src/ros-visualization/rqt_bag/rqt_bag_plugins/src/rqt_bag_plugins/image_view.py
+@@ -30,7 +30,7 @@
+ # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ # POSSIBILITY OF SUCH DAMAGE.
+ 
+-from PIL import Image
++from PIL import Image, ImageQt
+ 
+ # HACK workaround for upstream pillow issue python-pillow/Pillow#400
+ import sys
+@@ -40,7 +40,6 @@ if (
+     'PyQt5' in sys.modules
+ ):
+     sys.modules['PyQt5'] = None
+-from PIL.ImageQt import ImageQt
+ 
+ from rqt_bag import TopicMessageView
+ from rqt_bag_plugins import image_helper

--- a/ros2.repos
+++ b/ros2.repos
@@ -47,6 +47,78 @@ repositories:
     type: git
     url: https://github.com/ros-tooling/libstatistics_collector.git
     version: humble
+  ros-visualization/interactive_markers:
+    type: git
+    url: https://github.com/ros-visualization/interactive_markers.git
+    version: humble
+  ros-visualization/python_qt_binding:
+    type: git
+    url: https://github.com/ros-visualization/python_qt_binding.git
+    version: humble
+  ros-visualization/qt_gui_core:
+    type: git
+    url: https://github.com/ros-visualization/qt_gui_core.git
+    version: humble
+  ros-visualization/rqt:
+    type: git
+    url: https://github.com/ros-visualization/rqt.git
+    version: humble
+  ros-visualization/rqt_action:
+    type: git
+    url: https://github.com/ros-visualization/rqt_action.git
+    version: humble
+  ros-visualization/rqt_bag:
+    type: git
+    url: https://github.com/ros-visualization/rqt_bag.git
+    version: humble
+  ros-visualization/rqt_console:
+    type: git
+    url: https://github.com/ros-visualization/rqt_console.git
+    version: humble
+  ros-visualization/rqt_graph:
+    type: git
+    url: https://github.com/ros-visualization/rqt_graph.git
+    version: humble
+  ros-visualization/rqt_msg:
+    type: git
+    url: https://github.com/ros-visualization/rqt_msg.git
+    version: humble
+  ros-visualization/rqt_plot:
+    type: git
+    url: https://github.com/ros-visualization/rqt_plot.git
+    version: humble
+  ros-visualization/rqt_publisher:
+    type: git
+    url: https://github.com/ros-visualization/rqt_publisher.git
+    version: humble
+  ros-visualization/rqt_py_console:
+    type: git
+    url: https://github.com/ros-visualization/rqt_py_console.git
+    version: humble
+  ros-visualization/rqt_reconfigure:
+    type: git
+    url: https://github.com/ros-visualization/rqt_reconfigure.git
+    version: humble
+  ros-visualization/rqt_service_caller:
+    type: git
+    url: https://github.com/ros-visualization/rqt_service_caller.git
+    version: humble
+  ros-visualization/rqt_shell:
+    type: git
+    url: https://github.com/ros-visualization/rqt_shell.git
+    version: humble
+  ros-visualization/rqt_srv:
+    type: git
+    url: https://github.com/ros-visualization/rqt_srv.git
+    version: humble
+  ros-visualization/rqt_topic:
+    type: git
+    url: https://github.com/ros-visualization/rqt_topic.git
+    version: humble
+  ros-visualization/tango_icons_vendor:
+    type: git
+    url: https://github.com/ros-visualization/tango_icons_vendor.git
+    version: humble
   ros/class_loader:
     type: git
     url: https://github.com/ros/class_loader.git


### PR DESCRIPTION
I add to support rqt tools. I checked on the following environment.

- macOS Sonoma 14.0
- M1 MacBook Air

## Tests

### rqt_topic

<img width="955" alt="rqt_topic" src="https://github.com/TakanoTaiga/ros2_m1_native/assets/2630323/ae0b80b4-5868-4588-8683-c05a130bc0dc">

### rqt_plot

<img width="944" alt="rqt_plot" src="https://github.com/TakanoTaiga/ros2_m1_native/assets/2630323/280c3d52-c5ae-4ccc-9534-0afd7f026349">

### rqt_graph

<img width="900" alt="rqt_graph" src="https://github.com/TakanoTaiga/ros2_m1_native/assets/2630323/7529dba0-5867-4981-903f-fa23b604b586">

### rqt_bag
<img width="1032" alt="rqt_bag" src="https://github.com/TakanoTaiga/ros2_m1_native/assets/2630323/c60fadb6-74ee-469c-852b-f9fbc0035681">

### rqt_console

<img width="985" alt="rqt_console" src="https://github.com/TakanoTaiga/ros2_m1_native/assets/2630323/e43e60d4-e48b-4563-af07-da498637ce09">