### PR TITLE
Updated command to install pygraphviz

### DIFF
--- a/install_guide.md
+++ b/install_guide.md
@@ -26,9 +26,9 @@ brew uninstall --ignore-dependencies python@3.12 qt6
 
 ```bash
 python3.11 -m pip install -U pip
-python3.11 -m pip install --global-option=build_ext \
-       --global-option="-I$(brew --prefix graphviz)/include/" \
-       --global-option="-L$(brew --prefix graphviz)/lib/" \
+python3.11 -m pip install --config-settings="--global-option=build_ext" \
+       --config-settings="--global-option="-I$(brew --prefix graphviz)/include/"" \
+       --config-settings="--global-option="-L$(brew --prefix graphviz)/lib/"" \
        pygraphviz
 python3.11 -m pip install -U \
       argcomplete catkin_pkg colcon-common-extensions coverage \


### PR DESCRIPTION
There is the following description in `install_guide.md`.

```shell
python3.11 -m pip install -U pip
python3.11 -m pip install --global-option=build_ext \
       --global-option="-I$(brew --prefix graphviz)/include/" \
       --global-option="-L$(brew --prefix graphviz)/lib/" \
       pygraphviz
```

Now, pip 23.3.2 was installed in this command.  As a result, the installation of `pygraphviz` failed.
I found that `--global-option` option deprecated. <https://github.com/pypa/pip/issues/11859>

So, I changed option to install `pygraphviz`.